### PR TITLE
Feature: Added Cli-flags for controlling the dumping behavior

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,10 @@ optional arguments:
                         ignore the version from .kapitan
   --schemas-path SCHEMAS_PATH
                         set schema cache path, default is "./schemas"
+  --yaml-multiline-string-style STYLE
+                        set multiline string style to STYLE, default is 'double-quotes'
+  --yaml-dump-null-as-empty
+                        dumps all none-type entries as empty, default is dumping as 'null'
   --targets TARGET [TARGET ...], -t TARGET [TARGET ...]
                         targets to compile, default is all
   --labels [key=value [key=value ...]], -l [key=value [key=value ...]]

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -271,19 +271,20 @@ def build_parser():
     )
 
     compile_parser.add_argument(
-        "--multiline-string-rep",
+        "--multiline-string-style",
         type=str,
-        choices=('|', '>', '"'),
-        metavar="ARG",
-        default=from_dot_kapitan("compile", "multiline-string-rep", '"'),
-        help="set multiline string style to '|'",
+        choices=["literal", "folded", "double-quotes"],
+        metavar="STYLE",
+        action="store",
+        default=from_dot_kapitan("compile", "multiline-string-style", False),
+        help="set multiline string style to STYLE, default is 'double-quotes'",
     )
     
     compile_parser.add_argument(
-        "--dump-null",
-        default=from_dot_kapitan("compile", "dump-null", False),
+        "--dump-null-as-empty",
+        default=from_dot_kapitan("compile", "dump-null-as-empty", False),
         action="store_true",
-        help="dumps all none-type entries"
+        help="dumps all none-type entries as empty"
     )
 
     compile_selector_parser = compile_parser.add_mutually_exclusive_group()

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -279,12 +279,12 @@ def build_parser():
         default=from_dot_kapitan("compile", "multiline-string-style", "double-quotes"),
         help="set multiline string style to STYLE, default is 'double-quotes'",
     )
-    
+
     compile_parser.add_argument(
         "--dump-null-as-empty",
         default=from_dot_kapitan("compile", "dump-null-as-empty", False),
         action="store_true",
-        help="dumps all none-type entries as empty"
+        help="dumps all none-type entries as empty",
     )
 
     compile_selector_parser = compile_parser.add_mutually_exclusive_group()

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -271,20 +271,20 @@ def build_parser():
     )
 
     compile_parser.add_argument(
-        "--multiline-string-style",
+        "--yaml-multiline-string-style",
         type=str,
         choices=["literal", "folded", "double-quotes"],
         metavar="STYLE",
         action="store",
-        default=from_dot_kapitan("compile", "multiline-string-style", "double-quotes"),
+        default=from_dot_kapitan("compile", "yaml-multiline-string-style", "double-quotes"),
         help="set multiline string style to STYLE, default is 'double-quotes'",
     )
 
     compile_parser.add_argument(
-        "--dump-null-as-empty",
-        default=from_dot_kapitan("compile", "dump-null-as-empty", False),
+        "--yaml-dump-null-as-empty",
+        default=from_dot_kapitan("compile", "yaml-dump-null-as-empty", False),
         action="store_true",
-        help="dumps all none-type entries as empty",
+        help="dumps all none-type entries as empty, default is dumping as 'null'",
     )
 
     compile_selector_parser = compile_parser.add_mutually_exclusive_group()

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -270,6 +270,22 @@ def build_parser():
         help='set schema cache path, default is "./schemas"',
     )
 
+    compile_parser.add_argument(
+        "--multiline-string-rep",
+        type=str,
+        choices=('|', '>', '"'),
+        metavar="ARG",
+        default=from_dot_kapitan("compile", "multiline-string-rep", '"'),
+        help="set multiline string style to '|'",
+    )
+    
+    compile_parser.add_argument(
+        "--dump-null",
+        default=from_dot_kapitan("compile", "dump-null", False),
+        action="store_true",
+        help="dumps all none-type entries"
+    )
+
     compile_selector_parser = compile_parser.add_mutually_exclusive_group()
     compile_selector_parser.add_argument(
         "--targets",

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -276,7 +276,7 @@ def build_parser():
         choices=["literal", "folded", "double-quotes"],
         metavar="STYLE",
         action="store",
-        default=from_dot_kapitan("compile", "multiline-string-style", False),
+        default=from_dot_kapitan("compile", "multiline-string-style", "double-quotes"),
         help="set multiline string style to STYLE, default is 'double-quotes'",
     )
     

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -219,10 +219,13 @@ def multiline_str_presenter(dumper, data):
     Ref: https://github.com/yaml/pyyaml/issues/240#issuecomment-1018712495
     """
     # get parsed args from cached.py
-    cached_dict = cached.as_dict()
-    args = vars(cached_dict["args"]["compile"])
-    
-    style = args["multiline_string_style"]
+    try:
+        cached_dict = cached.as_dict()
+        args = vars(cached_dict["args"]["compile"])
+        
+        style = args["multiline_string_style"]
+    except KeyError:
+        style = None
 
     if style == "literal": 
         style = '|'
@@ -240,10 +243,13 @@ PrettyDumper.add_representer(str, multiline_str_presenter)
 def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
     # get parsed args from cached.py
-    cached_dict = cached.as_dict()
-    args = vars(cached_dict["args"]["compile"])
-    
-    flag_value = args["dump_null_as_empty"]
+    try:
+        cached_dict = cached.as_dict()
+        args = vars(cached_dict["args"]["compile"])
+        flag_value = args["dump_null_as_empty"]
+    except KeyError:
+        flag_value = None
+        
     if flag_value:
         return dumper.represent_scalar('tag:yaml.org,2002:null', '')
     else:

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -220,10 +220,7 @@ def multiline_str_presenter(dumper, data):
     """
     # get parsed args from cached.py
     try:
-        cached_dict = cached.as_dict()
-        args = vars(cached_dict["args"]["compile"])
-
-        style = args["multiline_string_style"]
+        style = cached.args["compile"].yaml_multiline_string_style
     except KeyError:
         style = None
 
@@ -245,9 +242,7 @@ def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
     # get parsed args from cached.py
     try:
-        cached_dict = cached.as_dict()
-        args = vars(cached_dict["args"]["compile"])
-        flag_value = args["dump_null_as_empty"]
+        flag_value = cached.args["compile"].yaml_dump_null_as_empty
     except KeyError:
         flag_value = None
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -214,12 +214,24 @@ class PrettyDumper(yaml.SafeDumper):
 
 def multiline_str_presenter(dumper, data):
     """
-    Configures yaml for dumping multiline strings with style='|'.
+    Configures yaml for dumping multiline strings with given style.
     By default, strings are getting dumped with style='"'.
     Ref: https://github.com/yaml/pyyaml/issues/240#issuecomment-1018712495
     """
-    args = vars(cached.as_dict()["args"]["compile"]) # get parsed args from cached.py
-    style = args["multiline_string_rep"]
+    # get parsed args from cached.py
+    cached_dict = cached.as_dict()
+    args = vars(cached_dict["args"]["compile"])
+    
+    flag = args["multiline_string_style"]
+    if flag:
+        style = flag
+    
+    if style == "literal": 
+        style = '|'
+    elif style == "folded":
+        style = '>'
+    else:
+        style = '"'
     if data.count('\n') > 0:  # check for multiline string
         return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
     return dumper.represent_scalar('tag:yaml.org,2002:str', data)
@@ -229,9 +241,13 @@ PrettyDumper.add_representer(str, multiline_str_presenter)
 
 def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
-    args = vars(cached.as_dict()["args"]["compile"]) # get parsed args from cached.py
-    flag = args["dump_null"]
-    if flag:
+    # get parsed args from cached.py
+    cached_dict = cached.as_dict()
+    args = vars(cached_dict["args"]["compile"])
+    print(args)
+    
+    flag_value = args["dump_null_as_empty"]
+    if flag_value:
         return dumper.represent_scalar('tag:yaml.org,2002:null', '')
     else:
         return dumper.represent_scalar('tag:yaml.org,2002:null', 'null')

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -222,10 +222,8 @@ def multiline_str_presenter(dumper, data):
     cached_dict = cached.as_dict()
     args = vars(cached_dict["args"]["compile"])
     
-    flag = args["multiline_string_style"]
-    if flag:
-        style = flag
-    
+    style = args["multiline_string_style"]
+
     if style == "literal": 
         style = '|'
     elif style == "folded":
@@ -244,7 +242,6 @@ def null_presenter(dumper, data):
     # get parsed args from cached.py
     cached_dict = cached.as_dict()
     args = vars(cached_dict["args"]["compile"])
-    print(args)
     
     flag_value = args["dump_null_as_empty"]
     if flag_value:

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -219,10 +219,10 @@ def multiline_str_presenter(dumper, data):
     Ref: https://github.com/yaml/pyyaml/issues/240#issuecomment-1018712495
     """
     # get parsed args from cached.py
-    try:
-        style = cached.args["compile"].yaml_multiline_string_style
-    except KeyError:
-        style = None
+    compile_args = cached.args.get("compile", None)
+    style = None
+    if compile_args:
+        style = compile_args.yaml_multiline_string_style
 
     if style == "literal":
         style = "|"
@@ -241,10 +241,10 @@ PrettyDumper.add_representer(str, multiline_str_presenter)
 def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
     # get parsed args from cached.py
-    try:
-        flag_value = cached.args["compile"].yaml_dump_null_as_empty
-    except KeyError:
-        flag_value = None
+    compile_args = cached.args.get("compile", None)
+    flag_value = None
+    if compile_args:
+        flag_value = compile_args.yaml_dump_null_as_empty
 
     if flag_value:
         return dumper.represent_scalar("tag:yaml.org,2002:null", "")

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -222,23 +222,24 @@ def multiline_str_presenter(dumper, data):
     try:
         cached_dict = cached.as_dict()
         args = vars(cached_dict["args"]["compile"])
-        
+
         style = args["multiline_string_style"]
     except KeyError:
         style = None
 
-    if style == "literal": 
-        style = '|'
+    if style == "literal":
+        style = "|"
     elif style == "folded":
-        style = '>'
+        style = ">"
     else:
         style = '"'
-    if data.count('\n') > 0:  # check for multiline string
-        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
-    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+    if data.count("\n") > 0:  # check for multiline string
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
 PrettyDumper.add_representer(str, multiline_str_presenter)
+
 
 def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
@@ -249,14 +250,15 @@ def null_presenter(dumper, data):
         flag_value = args["dump_null_as_empty"]
     except KeyError:
         flag_value = None
-        
+
     if flag_value:
-        return dumper.represent_scalar('tag:yaml.org,2002:null', '')
+        return dumper.represent_scalar("tag:yaml.org,2002:null", "")
     else:
-        return dumper.represent_scalar('tag:yaml.org,2002:null', 'null')
+        return dumper.represent_scalar("tag:yaml.org,2002:null", "null")
 
 
 PrettyDumper.add_representer(type(None), null_presenter)
+
 
 def flatten_dict(d, parent_key="", sep="."):
     """Flatten nested elements in a dictionary"""

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -218,10 +218,10 @@ def multiline_str_presenter(dumper, data):
     By default, strings are getting dumped with style='"'.
     Ref: https://github.com/yaml/pyyaml/issues/240#issuecomment-1018712495
     """
-    flag = True
-    if flag:
-        if data.count('\n') > 0:  # check for multiline string
-            return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    args = vars(cached.as_dict()["args"]["compile"]) # get parsed args from cached.py
+    style = args["multiline_string_rep"]
+    if data.count('\n') > 0:  # check for multiline string
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
     return dumper.represent_scalar('tag:yaml.org,2002:str', data)
 
 
@@ -229,7 +229,8 @@ PrettyDumper.add_representer(str, multiline_str_presenter)
 
 def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
-    flag = True
+    args = vars(cached.as_dict()["args"]["compile"]) # get parsed args from cached.py
+    flag = args["dump_null"]
     if flag:
         return dumper.represent_scalar('tag:yaml.org,2002:null', '')
     else:


### PR DESCRIPTION
**Added two new CLI-flags:**

1. `--multiline-string-style [STYLE]`
* Set representation of multiline string to given style (default: `"`)
* Available options:
  * `literal`: Using `|` as representation (turns every newline within the string into a literal newline)
  * `folded`: Using `>` as representation (removes single newlines within the string
  * `double-quotes`: Using `"` as representation (dumps newlines as `\n`-character in one string)
  * Find out more about yaml-strings [here](https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines)

2. `--dump-null-as-empty`
* Set representation of none-type-entries to ` ` (default: `null`)

**Solved Issues**
* https://github.com/kapicorp/kapitan/issues/852
* https://github.com/kapicorp/kapitan/issues/843
* https://github.com/kapicorp/kapitan/issues/859