### PR TITLE
feat(refs): add multiline string style option

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -548,6 +548,16 @@ def build_parser():
         help='set refs path, default is "./refs"',
         default=from_dot_kapitan("refs", "refs-path", "./refs"),
     )
+    refs_parser.add_argument(
+        "--yaml-multiline-string-style",
+        "-L",
+        type=str,
+        choices=["literal", "folded", "double-quotes"],
+        metavar="STYLE",
+        action="store",
+        default=from_dot_kapitan("refs", "yaml-multiline-string-style", "double-quotes"),
+        help="set multiline string style to STYLE, default is 'double-quotes'",
+    )
 
     lint_parser = subparser.add_parser(
         "lint", aliases=["l"], help="linter for inventory and refs", parents=[logger_parser]

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -223,15 +223,20 @@ def multiline_str_presenter(dumper, data):
     Ref: https://github.com/yaml/pyyaml/issues/240#issuecomment-1018712495
     """
     # get parsed args from cached.py
-    compile_args = cached.args.get("compile", None)
+    compile_args = cached.args.get("compile")
     style = None
     if compile_args:
         style = compile_args.yaml_multiline_string_style
 
     # check for inventory args too
-    inventory_args = cached.args.get("inventory", None)
+    inventory_args = cached.args.get("inventory")
     if inventory_args:
         style = inventory_args.multiline_string_style
+        
+    # check for refs args too
+    refs_args = cached.args.get("refs")
+    if refs_args:
+        style = refs_args.yaml_multiline_string_style
 
     if style == "literal":
         style = "|"


### PR DESCRIPTION
Introduces flag `--yaml-multiline-string-style` / `-L` with options `double-qoutes`, `folded` and `literal` for `kapitan refs` command.

@jrod-97 This will get refactored if the args have the new namespace system, so that not each command has  its own namespace for "global" flags. So pls don't worry about the repetition.
