### PR TITLE
feat(refs): add new env engine

### DIFF
--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -31,7 +31,7 @@ class Base64Ref(PlainRef):
         super().__init__(data, **kwargs)
         self.type_name = "base64"
         self.encoding = kwargs.get("encoding", "original")
-        self.embed_refs = kwargs.get("embed_refs", True)
+        self.embed_refs = kwargs.get("embed_refs", False)
 
         # TODO data should be bytes only
         if from_base64:

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -16,7 +16,7 @@ import unittest
 from kapitan.errors import RefError, RefFromFuncError, RefHashMismatchError
 from kapitan.refs.base import PlainRef, RefController, RefParams, Revealer
 from kapitan.refs.base64 import Base64Ref
-from kapitan.refs.env import DEFAULT_ENV_REF_VAR_PREFIX, EnvRef
+from kapitan.refs.env import DEFAULT_ENV_REF_VAR_PREFIX, EnvError, EnvRef
 from kapitan.utils import get_entropy
 
 REFS_HOME = tempfile.mkdtemp()
@@ -47,26 +47,26 @@ class Base64RefsTest(unittest.TestCase):
 
     def test_env_ref_compile(self):
         "check env ref compile() output is valid"
-        tag = "?{env:my/ref1_env}"
+        tag = "?{env:ref1_env}"
         REF_CONTROLLER[tag] = EnvRef(b"ref 1 env data")
         ref_obj = REF_CONTROLLER[tag]
         revealed = ref_obj.compile()
-        self.assertEqual(revealed, "?{env:my/ref1_env:877234e3}")
+        self.assertEqual(revealed, "?{env:ref1_env}")
 
     def test_env_ref_reveal_default(self):
         "check env ref reveal() output is original plain env data when environment var is not set"
-        tag = "?{env:my/ref1_env}"
+        tag = "?{env:ref1_env}"
         REF_CONTROLLER[tag] = EnvRef(b"ref 1 env data")
         ref_obj = REF_CONTROLLER[tag]
-        revealed = ref_obj.reveal()
-        self.assertEqual(revealed, "ref 1 env data")
+        with self.assertRaises(EnvError):
+            revealed = ref_obj.reveal()
 
     def test_env_ref_reveal_from_env(self):
         "check env ref reveal() output is value of environment var data when environment var is set"
-        tag = "?{env:my/ref1_env}"
+        tag = "?{env:ref1_env}"
         REF_CONTROLLER[tag] = EnvRef(b"ref 1 env data")
         ref_obj = REF_CONTROLLER[tag]
-        os.environ["{}{}".format(DEFAULT_ENV_REF_VAR_PREFIX, "ref1_env")] = "ref 1 env data from EV"
+        os.environ[f"{DEFAULT_ENV_REF_VAR_PREFIX}ref1_env"] = "ref 1 env data from EV"
         revealed = ref_obj.reveal()
         self.assertEqual(revealed, "ref 1 env data from EV")
 


### PR DESCRIPTION
## Proposed Changes
- reworked `env` ref engine
- new usage: `?{env:MYENV}` or `?{env:myenv}`
- new env prefix: `KAPITAN_ENV` (like in the docs haha)
- reveal --> get value (if not defined --> error)
